### PR TITLE
Fix: branch naming rule on creation is not supported

### DIFF
--- a/.github/workflows/branch-naming-rules.yml
+++ b/.github/workflows/branch-naming-rules.yml
@@ -1,8 +1,7 @@
 name: branch-naming-rules
 
 on:
-  pull_request:
-    types: [opened, reopened]
+  pull_request
 
 jobs:
   branch-naming-rules:

--- a/.github/workflows/branch-naming-rules.yml
+++ b/.github/workflows/branch-naming-rules.yml
@@ -1,7 +1,8 @@
 name: branch-naming-rules
 
 on:
-  pull_request
+  pull_request:
+    types: [opened,synchronize,reopened]
 
 jobs:
   branch-naming-rules:

--- a/.github/workflows/branch-naming-rules.yml
+++ b/.github/workflows/branch-naming-rules.yml
@@ -1,7 +1,8 @@
 name: branch-naming-rules
 
 on:
-  create
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   branch-naming-rules:

--- a/.github/workflows/branch-naming-rules.yml
+++ b/.github/workflows/branch-naming-rules.yml
@@ -1,10 +1,7 @@
 name: branch-naming-rules
 
 on:
-  create:
-    branches: ["**"]
-  pull_request:
-    types: [opened]
+  create
 
 jobs:
   branch-naming-rules:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -1,5 +1,5 @@
 # Inspiration: https://github.com/fpgmaas/deptry
-name: quality_checks
+name: quality-checks
 
 on:
   workflow_call:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -10,7 +10,7 @@ on:
         description: 'Provide pre-commit hooks to skip as a comma-separated list, e.g. SKIP=no-commit-to-branch,deptry'
 
 jobs:
-  quality:
+  quality-checks:
     runs-on: ubuntu-latest
     steps:
       - name: Check out


### PR DESCRIPTION
Closes #45. Already raised in https://github.com/deepakputhraya/action-branch-name/issues/17. Repo seems inactive but maintainer is active on Github so tagged them in the issue.

Temporary solution added.